### PR TITLE
fix: run badge unlock animation only when it is in viewport

### DIFF
--- a/src/components/Badge/BadgeCollection.js
+++ b/src/components/Badge/BadgeCollection.js
@@ -52,13 +52,20 @@ export default function BadgeCollection({ showOnlyNearCompletion = false }) {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-          badgeId: badge.badgeId
-        })
+        body: JSON.stringify({ badgeId: badge.badgeId })
       });
 
       if (response.ok) {
         console.log(`Badge ${badge.badgeId} marked as viewed`);
+
+        // Mark badge as viewed
+        setProgress((prev) => ({
+          ...prev,
+          [badge.badgeId]: {
+            ...prev[badge.badgeId],
+            isViewed: true
+          }
+        }));
       } else {
         console.error('Failed to mark badge as viewed:', response.statusText);
       }

--- a/src/components/Badge/BadgeDemo.js
+++ b/src/components/Badge/BadgeDemo.js
@@ -1,24 +1,11 @@
 import { BADGE_COLLECTION } from '@/lib/badge/badgeCollection';
 import { Filter, Grid, List, Search, Trophy } from 'lucide-react';
+import Link from 'next/link';
 import React, { useState } from 'react';
 import BadgeShowcase from './BadgeShowcase';
 
 // Sample user badges progress
 const sampleUserBadges = {
-  ['lightning_fingers_80']: {
-    unlocked: false,
-    progress: 75,
-    currentValue: 20,
-    targetValue: 80,
-    unlockedAt: '2025-10-10T14:06:04.340Z',
-    isViewed: false
-  },
-  ['accuracy_expert_95']: {
-    unlocked: true,
-    progress: 100,
-    unlockedAt: '2025-10-10T14:06:04.340Z',
-    isViewed: false
-  },
   ['first_steps']: {
     unlocked: true,
     progress: 100,
@@ -30,13 +17,6 @@ const sampleUserBadges = {
     progress: 20,
     currentValue: 20,
     targetValue: 100,
-    isViewed: false
-  },
-  ['aim_high']: {
-    unlocked: false,
-    progress: 40,
-    currentValue: 4,
-    targetValue: 10,
     isViewed: false
   }
 };
@@ -68,7 +48,7 @@ export default function BadgeDemo() {
     console.log('Badge clicked:', badge);
   };
 
-  const handleBadgeAnimationComplete = (badge) => {
+  const handleBadgeAnimationComplete = (animationName, badge) => {
     console.log('Animation completed for badge:', badge.name);
     // Update the badge to mark it as viewed
     setUserBadges((prev) => ({
@@ -140,8 +120,9 @@ export default function BadgeDemo() {
             <h3 className="text-lg font-medium text-white mb-3">Test Celebration Animations</h3>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
               {BADGE_COLLECTION.map((badge) => (
-                <button
+                <Link
                   key={badge.badgeId}
+                  href={`#${badge.badgeId}`}
                   onClick={() => simulateUnlock(badge.badgeId)}
                   className={`px-3 py-2 rounded text-sm font-medium transition-colors ${
                     badge.rarity === 'legendary'
@@ -156,7 +137,7 @@ export default function BadgeDemo() {
                   Unlock {badge.name}
                   <br />
                   <span className="text-xs opacity-75">({badge.rarity})</span>
-                </button>
+                </Link>
               ))}
             </div>
             <button

--- a/src/components/Badge/toast.js
+++ b/src/components/Badge/toast.js
@@ -7,7 +7,7 @@ import { BadgePic, BadgeRarity } from './BadgeHelper';
 
 function BadgeContent({ badge, closeToast, toastProps }) {
   return (
-    <Link href="/profile" onClick={() => closeToast()}>
+    <Link href={`/profile#${badge.badgeId}`} onClick={() => closeToast()}>
       <div className="flex items-center gap-4">
         <div className="flex flex-col items-center gap-2">
           <BadgePic badge={badge} isUnlocked />

--- a/src/hooks/intersection-observer.js
+++ b/src/hooks/intersection-observer.js
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Detect when an element enters the viewport
+ *
+ * @param {Object} options Intersection Observer options
+ * @param {element} options.root - The element that is used as the viewport for checking visibility
+ *   of the target. Must be the ancestor of the target. Defaults to the browser viewport if not
+ *   specified or if null.
+ * @param {string} options.rootMargin - Margin around the root. A string of one to four values
+ *   similar to the CSS margin property, e.g., "10px 20px 30px 40px" (top, right, bottom, left). The
+ *   values can only be in pixels (px) or percentages (%). This set of values serves to grow or
+ *   shrink each side of the root element's bounding box before computing intersections. Negative
+ *   values will shrink the bounding box of the root element and positive values will expand it. The
+ *   default value, if not specified, is "0px 0px 0px 0px".
+ * @param {number} options.threshold - Either a single number or an array of numbers which indicate
+ *   at what percentage of the target's visibility the observer's callback should be executed. If
+ *   you only want to detect when visibility passes the 50% mark, you can use a value of 0.5. If you
+ *   want the callback to run every time visibility passes another 25%, you would specify the array
+ *   [0, 0.25, 0.5, 0.75, 1]. The default is 0 (meaning as soon as even one pixel is visible, the
+ *   callback will be run). A value of 1.0 means that the threshold isn't considered passed until
+ *   every pixel is visible.
+ * @returns {[ref, boolean]} A tuple containing:
+ *
+ *   - `ref`: the reference to the element to observe
+ *   - `isIntersecting`: whether the element is intersecting the viewport
+ */
+export const useIntersectionObserver = (options) => {
+  const ref = useRef(null);
+  const [isIntersecting, setIntersecting] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setIntersecting(entry.isIntersecting);
+    }, options);
+    const elem = ref.current;
+
+    if (elem) {
+      observer.observe(elem);
+    }
+
+    return () => {
+      if (elem) {
+        observer.unobserve(elem);
+      }
+      observer.disconnect();
+    };
+  }, [options]);
+
+  return [ref, isIntersecting];
+};


### PR DESCRIPTION
Fixes #97

- add a new `userIntersectionObserver` hook to detect when element is in viewport
- show badge unlock animation only when it is in viewport
- jump to view badge immediately when clicking on the new achievement toast